### PR TITLE
CCD-2117: Address CVE-2021-42340

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,12 @@ dependencyManagement {
     dependencySet(group: 'com.google.guava', version: '30.1.1-jre') {
       entry 'guava'
     }
+    // CVE-2021-42340
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.54') {
+      entry 'tomcat-embed-core'
+      entry 'tomcat-embed-el'
+      entry 'tomcat-embed-websocket'
+    }
   }
 }
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,8 +15,4 @@
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2020-7712</cve>
   </suppress>
-  <suppress until="2021-11-25">
-    <notes>Suppress CVE affecting Tomcat temporarily until it can be addressed</notes>
-    <cve>CVE-2021-42340</cve>
-  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,4 +15,8 @@
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2020-7712</cve>
   </suppress>
+  <suppress until="2021-11-25">
+    <notes>Suppress CVE affecting spring-core temporarily until it can be addressed</notes>
+    <cve>CVE-2021-22096</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2117 (https://tools.hmcts.net/jira/browse/CCD-2117)


### Change description ###
- Updated dependencyManagement section of build.gradle. Added dependencySet entry for org.apache.tomcat.embed group to resolve CVE-2021-42340.
- Removed suppression of CVE-2021-42340 from suppressions.xml.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
