### PR TITLE
CCD-2134: Address CVE-2021-22096

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,8 @@ ext.libraries = [
   ]
 ]
 
+ext['spring-framework.version'] = '5.3.12'
+
 dependencies {
   implementation group: 'javax.inject', name: 'javax.inject', version: '1'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  
   <suppress until="2030-01-01">
     <notes><![CDATA[
      Suppressing as it's a false positive (see: https://pivotal.io/security/cve-2018-1258)
@@ -8,6 +9,7 @@
     <cpe>cpe:/a:pivotal_software:spring_security</cpe>
     <cve>CVE-2018-1258</cve>
   </suppress>
+
   <suppress>
     <notes><![CDATA[
         CVE is a json vulnerability for Node projects. False positive reported at https://github.com/jeremylong/DependencyCheck/issues/2794
@@ -15,4 +17,5 @@
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2020-7712</cve>
   </suppress>
+
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,8 +15,4 @@
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2020-7712</cve>
   </suppress>
-  <suppress until="2021-11-25">
-    <notes>Suppress CVE affecting spring-core temporarily until it can be addressed</notes>
-    <cve>CVE-2021-22096</cve>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2134 (https://tools.hmcts.net/jira/browse/CCD-2134)


### Change description ###
- Updated build.gradle.  Added override of spring-framework.version property with value set to 5.3.12 to address CVE-2021-22096.
- Removed temporary suppression of CVE-2021-22096 from suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
