### PR TITLE
CCD-2189: Upgrade elasticsearch client version to address CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,7 @@ def versions = [
   junit           : '5.7.2',
   junitPlatform   : '1.7.2',
   reformLogging   : '5.1.7',
-  elasticsearch   : '6.4.2',
+  elasticsearch   : '6.8.17',
   testcontainers  : '1.16.0',
   springBoot      : springBoot.class.package.implementationVersion
 ]

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -18,19 +18,4 @@
     <cve>CVE-2020-7712</cve>
   </suppress>
 
-  <suppress>
-    <notes><![CDATA[
-        Elastic search 6.4.2
-    ]]></notes>
-    <cve>CVE-2018-17244</cve>
-    <cve>CVE-2019-7611</cve>
-    <cve>CVE-2019-7614</cve>
-    <cve>CVE-2020-7019</cve>
-    <cve>CVE-2020-7020</cve>
-    <cve>CVE-2020-7021</cve>
-    <cve>CVE-2021-22135</cve>
-    <cve>CVE-2021-22137</cve>
-    <cve>CVE-2021-22144</cve>
-  </suppress>
-
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2189 (https://tools.hmcts.net/jira/browse/CCD-2189)


### Change description ###
Updated build.gradle.  Changed version of elasticsearch client to 6.8.17 to address the following 9 CVEs:

- CVE-2018-17244
- CVE-2019-7611
- CVE-2019-7614
- CVE-2020-7019
- CVE-2020-7020
- CVE-2020-7021
- CVE-2021-22135
- CVE-2021-22137
- CVE-2021-22144

Also removed these CVEs from suppressions.xml



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
