### PR TITLE
CCD 3096 Update 'spring-framework.version' to '5.3.19' and removal of suppression CVE-2022-22968

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ ext.libraries = [
         ]
 ]
 
-ext['spring-framework.version'] = '5.3.18'
+ext['spring-framework.version'] = '5.3.19'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.13.2'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -46,14 +46,4 @@
      <cve>CVE-2021-22144</cve>
    </suppress>
 
-  <!--
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-core-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-  -->
-
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -46,6 +46,7 @@
      <cve>CVE-2021-22144</cve>
    </suppress>
 
+  <!--
   <suppress until="2022-05-25">
     <notes><![CDATA[
    file name: spring-core-5.3.18.jar
@@ -53,5 +54,6 @@
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
     <cve>CVE-2022-22968</cve>
   </suppress>
+  -->
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3096


### Change description ###

1. Updated build.gradle (ext['spring-framework.version'] = '5.3.18' changed to ext['spring-framework.version'] = '5.3.19')
2. Removed suppression for CVE-2022-22968 from config/owasp/ suppressions.xml

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
