### PR TITLE
LAU-439: Update to ensure missing TTLs don't break app.

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/ccd/data/DeletionScenarios.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/ccd/data/DeletionScenarios.java
@@ -72,18 +72,18 @@ public class DeletionScenarios {
                         "FT_MasterCaseType",
                         null,
                         "scenarios/S-005-unexpired-cases-and-nondeletable-case-types-present.sql",
-                        List.of(1L, 2L, 3L, 4L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353527L, 1504259907353528L, 1504259907353529L),
-                                "FT_MultiplePages", List.of(1504259907353526L)
+                        List.of(1L, 2L, 3L, 4L, 5L),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353527L, 1504259907353528L, 1504259907353529L, 1504259907353526L),
+                                "FT_MultiplePages", List.of(1504259907353525L)
                         ),
-                        List.of(3L, 4L),
+                        List.of(3L, 4L, 5L),
                         emptyList(),
                         List.of(1504259907353528L, 1504259907353529L),
                         Map.of("FT_MasterCaseType", List.of(1504259907353528L, 1504259907353529L),
                                 "FT_MultiplePages", emptyList()
                         ),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353527L),
-                                "FT_MultiplePages", List.of(1504259907353526L)
+                        Map.of("FT_MasterCaseType", List.of(1504259907353527L, 1504259907353526L),
+                                "FT_MultiplePages", List.of(1504259907353525L)
                         )
                 ),
                 // Scenario 6
@@ -92,16 +92,16 @@ public class DeletionScenarios {
                         null,
                         "scenarios/S-005-unexpired-cases-and-nondeletable-case-types-present.sql",
                         List.of(1L, 2L, 3L, 4L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353527L, 1504259907353528L, 1504259907353529L),
-                                "FT_MultiplePages", List.of(1504259907353526L)
+                        Map.of("FT_MasterCaseType", List.of(1504259907353527L, 1504259907353528L, 1504259907353529L, 1504259907353526L),
+                                "FT_MultiplePages", List.of(1504259907353525L)
                         ),
-                        List.of(3L),
+                        List.of(3L, 4L),
                         emptyList(),
-                        List.of(1504259907353528L, 1504259907353529L, 1504259907353526L),
+                        List.of(1504259907353528L, 1504259907353529L, 1504259907353525L),
                         Map.of("FT_MasterCaseType", List.of(1504259907353528L, 1504259907353529L),
-                                "FT_MultiplePages", List.of(1504259907353526L)
+                                "FT_MultiplePages", List.of(1504259907353525L)
                         ),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353527L),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353527L, 1504259907353526L),
                                 "FT_MultiplePages", emptyList()
                         )
                 ),
@@ -239,17 +239,17 @@ public class DeletionScenarios {
                         "FT_MasterCaseType",
                         null,
                         "scenarios/S-013-cases-due-deletion-linked-to-third-level-deep-nondeletable-case.sql",
-                        List.of(1L, 2L, 3L, 4L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L, 1504259907353527L),
+                        List.of(1L, 2L, 3L, 4L, 5L, 6L),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L, 1504259907353527L, 1504259907353525L, 1504259907353524L),
                                 "FT_MultiplePages", List.of(1504259907353526L)
                         ),
-                        List.of(1L, 2L, 3L, 4L),
+                        List.of(1L, 2L, 3L, 4L, 5L, 6L),
                         emptyList(),
                         emptyList(),
                         Map.of("FT_MasterCaseType", emptyList(),
                                 "FT_MultiplePages", emptyList()
                         ),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L, 1504259907353527L),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L, 1504259907353527L, 1504259907353525L, 1504259907353524L),
                                 "FT_MultiplePages", List.of(1504259907353526L)
                         )
                 ),

--- a/src/integrationTest/java/uk/gov/hmcts/reform/ccd/data/DeletionScenarios.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/ccd/data/DeletionScenarios.java
@@ -73,7 +73,8 @@ public class DeletionScenarios {
                         null,
                         "scenarios/S-005-unexpired-cases-and-nondeletable-case-types-present.sql",
                         List.of(1L, 2L, 3L, 4L, 5L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353527L, 1504259907353528L, 1504259907353529L, 1504259907353526L),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353527L, 1504259907353528L,
+                                                                1504259907353529L, 1504259907353526L),
                                 "FT_MultiplePages", List.of(1504259907353525L)
                         ),
                         List.of(3L, 4L, 5L),
@@ -92,7 +93,8 @@ public class DeletionScenarios {
                         null,
                         "scenarios/S-005-unexpired-cases-and-nondeletable-case-types-present.sql",
                         List.of(1L, 2L, 3L, 4L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353527L, 1504259907353528L, 1504259907353529L, 1504259907353526L),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353527L, 1504259907353528L,
+                                                                1504259907353529L, 1504259907353526L),
                                 "FT_MultiplePages", List.of(1504259907353525L)
                         ),
                         List.of(3L, 4L),
@@ -110,7 +112,8 @@ public class DeletionScenarios {
                         null,
                         "scenarios/S-007-deletable-case-linked-to-nondeletable-ttl-case.sql",
                         List.of(1L, 2L, 3L, 4L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353526L, 1504259907353528L, 1504259907353529L),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353526L, 1504259907353528L,
+                                                                1504259907353529L),
                                 "FT_MultiplePages", List.of(1504259907353527L)
                         ),
                         List.of(1L, 3L, 4L),
@@ -149,8 +152,9 @@ public class DeletionScenarios {
                         null,
                         "scenarios/S-009-nondeletable-ttl-case-linked-to-deletable-case.sql",
                         List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353523L, 1504259907353524L, 1504259907353525L,
-                                        1504259907353527L, 1504259907353528L, 1504259907353529L
+                        Map.of("FT_MasterCaseType", List.of(1504259907353523L, 1504259907353524L,
+                                                                1504259907353525L, 1504259907353527L,
+                                                                1504259907353528L, 1504259907353529L
                                 ),
                                 "FT_MultiplePages", List.of(1504259907353526L)
                         ),
@@ -173,8 +177,9 @@ public class DeletionScenarios {
                         null,
                         "scenarios/S-010-deletable-cases-linked-to-multiple-nondeletable-cases.sql",
                         List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353523L, 1504259907353524L, 1504259907353525L,
-                                        1504259907353527L, 1504259907353528L, 1504259907353529L
+                        Map.of("FT_MasterCaseType", List.of(1504259907353523L, 1504259907353524L,
+                                                                1504259907353525L, 1504259907353527L,
+                                                                1504259907353528L, 1504259907353529L
                                 ),
                                 "FT_MultiplePages", List.of(1504259907353526L)
                         ),
@@ -196,11 +201,13 @@ public class DeletionScenarios {
                         null,
                         "scenarios/S-011-mix-bag-of-deletable-and-nondeletable-cases.sql",
                         List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353522L, 1504259907353523L, 1504259907353524L,
-                                        1504259907353525L, 1504259907353528L, 1504259907353529L
+                        Map.of("FT_MasterCaseType", List.of(1504259907353522L, 1504259907353523L,
+                                                                1504259907353524L, 1504259907353525L,
+                                                                1504259907353528L, 1504259907353529L
                                 ),
-                                "FT_MultiplePages", List.of(1504259907353518L, 1504259907353519L, 1504259907353521L,
-                                        1504259907353526L, 1504259907353527L
+                                "FT_MultiplePages", List.of(1504259907353518L, 1504259907353519L,
+                                                                1504259907353521L, 1504259907353526L,
+                                                                1504259907353527L
                                 ),
                                 "FT_Conditionals", List.of(1504259907353520L)
                         ),
@@ -208,11 +215,14 @@ public class DeletionScenarios {
                         emptyList(),
                         List.of(1504259907353522L, 1504259907353523L, 1504259907353528L, 1504259907353518L,
                                 1504259907353519L, 1504259907353526L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353522L, 1504259907353523L, 1504259907353528L),
-                                "FT_MultiplePages", List.of(1504259907353518L, 1504259907353519L, 1504259907353526L),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353522L, 1504259907353523L,
+                                                                1504259907353528L),
+                                "FT_MultiplePages", List.of(1504259907353518L, 1504259907353519L,
+                                                                1504259907353526L),
                                 "FT_Conditionals", emptyList()
                         ),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353524L, 1504259907353525L, 1504259907353529L),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353524L, 1504259907353525L,
+                                                                1504259907353529L),
                                 "FT_MultiplePages", List.of(1504259907353521L, 1504259907353527L),
                                 "FT_Conditionals", List.of(1504259907353520L)
                         )
@@ -240,7 +250,9 @@ public class DeletionScenarios {
                         null,
                         "scenarios/S-013-cases-due-deletion-linked-to-third-level-deep-nondeletable-case.sql",
                         List.of(1L, 2L, 3L, 4L, 5L, 6L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L, 1504259907353527L, 1504259907353525L, 1504259907353524L),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L,
+                                                                1504259907353527L, 1504259907353525L,
+                                                                1504259907353524L),
                                 "FT_MultiplePages", List.of(1504259907353526L)
                         ),
                         List.of(1L, 2L, 3L, 4L, 5L, 6L),
@@ -249,7 +261,9 @@ public class DeletionScenarios {
                         Map.of("FT_MasterCaseType", emptyList(),
                                 "FT_MultiplePages", emptyList()
                         ),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L, 1504259907353527L, 1504259907353525L, 1504259907353524L),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L,
+                                                                1504259907353527L, 1504259907353525L,
+                                                                1504259907353524L),
                                 "FT_MultiplePages", List.of(1504259907353526L)
                         )
                 ),
@@ -267,7 +281,8 @@ public class DeletionScenarios {
                         Map.of("FT_MasterCaseType", emptyList(),
                                 "FT_MultiplePages", emptyList()
                         ),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L, 1504259907353527L),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L,
+                                                               1504259907353527L),
                                 "FT_MultiplePages", List.of(1504259907353526L)
                         )
                 ),
@@ -276,11 +291,13 @@ public class DeletionScenarios {
                         null,
                         "scenarios/S-015-case-links-three-levels-deep.sql",
                         List.of(1L, 2L, 3L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L, 1504259907353527L)),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L,
+                                                                1504259907353527L)),
                         emptyList(),
                         emptyList(),
                         List.of(1504259907353529L, 1504259907353528L, 1504259907353527L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L, 1504259907353527L)),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L,
+                                                                1504259907353527L)),
                         Map.of("FT_MasterCaseType", emptyList())
                 ),
                 Arguments.of(
@@ -288,13 +305,15 @@ public class DeletionScenarios {
                         null,
                         "scenarios/S-016-deletable-multi-parent-case.sql",
                         List.of(1L, 2L, 3L, 4L, 5L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L, 1504259907353527L,
-                                1504259907353526L, 1504259907353525L)),
+                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L,
+                                                                1504259907353527L, 1504259907353526L,
+                                                                1504259907353525L)),
                         emptyList(),
                         emptyList(),
                         List.of(1504259907353529L, 1504259907353528L, 1504259907353527L,
                                 1504259907353526L, 1504259907353525L),
-                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L, 1504259907353527L,
+                        Map.of("FT_MasterCaseType", List.of(1504259907353529L, 1504259907353528L,
+                                                                1504259907353527L,
                                 1504259907353526L, 1504259907353525L)),
                         Map.of("FT_MasterCaseType", emptyList())
                 ),

--- a/src/integrationTest/resources/scenarios/S-005-unexpired-cases-and-nondeletable-case-types-present.sql
+++ b/src/integrationTest/resources/scenarios/S-005-unexpired-cases-and-nondeletable-case-types-present.sql
@@ -39,7 +39,7 @@ VALUES (3, 'FT_MasterCaseType', 'BEFTA_MASTER', 'CaseCreated', 'PUBLIC',
 );
 
 INSERT INTO case_data (id, case_type_id, jurisdiction, state, security_classification, data, data_classification, reference, resolved_ttl)
-VALUES (4, 'FT_MultiplePages', 'BEFTA_MASTER', 'CaseCreated', 'PUBLIC',
+VALUES (4, 'FT_MasterCaseType', 'BEFTA_MASTER', 'CaseCreated', 'PUBLIC',
         '{
           "PersonFirstName": "Janet"
         }',
@@ -47,5 +47,17 @@ VALUES (4, 'FT_MultiplePages', 'BEFTA_MASTER', 'CaseCreated', 'PUBLIC',
          "PersonFirstName": "PUBLIC"
        }',
        1504259907353526,
+       null
+);
+
+INSERT INTO case_data (id, case_type_id, jurisdiction, state, security_classification, data, data_classification, reference, resolved_ttl)
+VALUES (5, 'FT_MultiplePages', 'BEFTA_MASTER', 'CaseCreated', 'PUBLIC',
+        '{
+          "PersonFirstName": "Janet"
+        }',
+       '{
+         "PersonFirstName": "PUBLIC"
+       }',
+       1504259907353525,
        '2016-06-24 20:44:52.824'
 );

--- a/src/integrationTest/resources/scenarios/S-013-cases-due-deletion-linked-to-third-level-deep-nondeletable-case.sql
+++ b/src/integrationTest/resources/scenarios/S-013-cases-due-deletion-linked-to-third-level-deep-nondeletable-case.sql
@@ -50,6 +50,30 @@ VALUES (4, 'FT_MultiplePages', 'BEFTA_MASTER', 'CaseCreated', 'PUBLIC',
        CURRENT_DATE
 );
 
+INSERT INTO case_data (id, case_type_id, jurisdiction, state, security_classification, data, data_classification, reference, resolved_ttl)
+VALUES (5, 'FT_MasterCaseType', 'BEFTA_MASTER', 'CaseCreated', 'PUBLIC',
+        '{
+          "PersonFirstName": "Janet"
+        }',
+       '{
+         "PersonFirstName": "PUBLIC"
+       }',
+       1504259907353525,
+       '2016-06-24 20:44:52.824'
+);
+
+INSERT INTO case_data (id, case_type_id, jurisdiction, state, security_classification, data, data_classification, reference, resolved_ttl)
+VALUES (6, 'FT_MasterCaseType', 'BEFTA_MASTER', 'CaseCreated', 'PUBLIC',
+        '{
+          "PersonFirstName": "Janet"
+        }',
+       '{
+         "PersonFirstName": "PUBLIC"
+       }',
+       1504259907353524,
+       null
+);
+
 INSERT INTO case_link (case_id, case_type_id, linked_case_id)
 VALUES (1, 'FT_MasterCaseType', 2);
 
@@ -58,3 +82,6 @@ VALUES (1, 'FT_MasterCaseType', 3);
 
 INSERT INTO case_link (case_id, case_type_id, linked_case_id)
 VALUES (3, 'FT_MultiplePages', 4);
+
+INSERT INTO case_link (case_id, case_type_id, linked_case_id)
+VALUES (5, 'FT_MasterCaseType', 6);

--- a/src/main/java/uk/gov/hmcts/reform/ccd/policy/TtlRetentionPolicyImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/policy/TtlRetentionPolicyImpl.java
@@ -13,6 +13,6 @@ public class TtlRetentionPolicyImpl implements RetentionPolicy {
 
     private boolean isExpired(final LocalDate caseTtl) {
         final LocalDate today = LocalDate.now();
-        return caseTtl != null ? caseTtl.isBefore(today) : false;
+        return caseTtl != null && caseTtl.isBefore(today);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/ccd/policy/TtlRetentionPolicyImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/policy/TtlRetentionPolicyImpl.java
@@ -11,8 +11,8 @@ public class TtlRetentionPolicyImpl implements RetentionPolicy {
         return !isExpired(caseData.getResolvedTtl());
     }
 
-    private boolean isExpired(@NonNull final LocalDate caseTtl) {
+    private boolean isExpired(final LocalDate caseTtl) {
         final LocalDate today = LocalDate.now();
-        return caseTtl.isBefore(today);
+        return caseTtl != null ? caseTtl.isBefore(today) : false;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/ccd/service/remote/RestClientBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/service/remote/RestClientBuilder.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.ccd.service.remote;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.glassfish.jersey.client.ClientConfig;
-import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.logging.LoggingFeature;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.util.SecurityUtil;
@@ -11,6 +11,8 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 
+import static org.glassfish.jersey.client.ClientProperties.CONNECT_TIMEOUT;
+import static org.glassfish.jersey.client.ClientProperties.READ_TIMEOUT;
 import static uk.gov.hmcts.reform.ccd.util.RestConstants.AUTHORISATION_HEADER;
 import static uk.gov.hmcts.reform.ccd.util.RestConstants.SERVICE_AUTHORISATION_HEADER;
 
@@ -54,11 +56,12 @@ public class RestClientBuilder {
                 .post(Entity.json(body));
     }
 
-    private Client getClient() {
+    @VisibleForTesting
+    protected Client getClient() {
         if (client == null) {
             final ClientConfig clientConfig = new ClientConfig()
-                    .property(ClientProperties.READ_TIMEOUT, CLIENT_READ_TIMEOUT)
-                    .property(ClientProperties.CONNECT_TIMEOUT, CLIENT_CONNECT_TIMEOUT);
+                    .property(READ_TIMEOUT, CLIENT_READ_TIMEOUT)
+                    .property(CONNECT_TIMEOUT, CLIENT_CONNECT_TIMEOUT);
 
             client = ClientBuilder
                     .newClient(clientConfig)

--- a/src/test/java/uk/gov/hmcts/reform/ccd/fixture/TestData.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/fixture/TestData.java
@@ -59,6 +59,8 @@ public interface TestData {
             new CaseData(1000L, 1000L, DELETABLE_CASE_TYPE, YESTERDAY, 1000L, null);
     CaseData NON_DELETABLE_CASE_DATA_WITH_PAST_TTL =
             new CaseData(21L, 21L, NON_DELETABLE_CASE_TYPE, YESTERDAY, 21L, null);
+    CaseData NON_DELETABLE_CASE_DATA_WITH_MISSING_TTL =
+        new CaseData(22L, 22L, NON_DELETABLE_CASE_TYPE, null, 22L, null);
     CaseFamily NON_DELETABLE_CASE_FAMILY = new CaseFamily(NON_DELETABLE_CASE_DATA_WITH_PAST_TTL,
             asList(NON_DELETABLE_CASE_DATA_WITH_PAST_TTL,
                     NON_DELETABLE_CASE_DATA_WITH_PAST_TTL));
@@ -90,6 +92,7 @@ public interface TestData {
             .build();
     CaseData DELETABLE_CASE_DATA_WITH_FUTURE_TTL = new CaseData(3L, 3L, DELETABLE_CASE_TYPE, TOMORROW, 3L, null);
     CaseData LINKED_CASE_DATA_R101 = new CaseData(101L, 101L, DELETABLE_CASE_TYPE, TOMORROW, 101L, null);
+    CaseData LINKED_CASE_DATA_MISSING_TTL_R102 = new CaseData(102L, 102L, DELETABLE_CASE_TYPE, null, 101L, null);
     CaseDataEntity DELETABLE_CASE_ENTITY_WITH_TODAY_TTL = new CaseDataEntityBuilder(2L)
             .withReference(2L)
             .withCaseType(DELETABLE_CASE_TYPE)

--- a/src/test/java/uk/gov/hmcts/reform/ccd/policy/CaseTypeRetentionPolicyImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/policy/CaseTypeRetentionPolicyImplTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.mockito.Mockito.doReturn;
 import static uk.gov.hmcts.reform.ccd.fixture.TestData.DELETABLE_CASE_DATA_WITH_TODAY_TTL;
+import static uk.gov.hmcts.reform.ccd.fixture.TestData.NON_DELETABLE_CASE_DATA_WITH_MISSING_TTL;
 import static uk.gov.hmcts.reform.ccd.fixture.TestData.NON_DELETABLE_CASE_DATA_WITH_PAST_TTL;
 import static uk.gov.hmcts.reform.ccd.fixture.TestData.TODAY;
 
@@ -73,6 +74,7 @@ class CaseTypeRetentionPolicyImplTest {
         return Stream.of(
             Arguments.of(List.of(TestData.DELETABLE_CASE_TYPE), DELETABLE_CASE_DATA_WITH_TODAY_TTL, false),
             Arguments.of(List.of(TestData.DELETABLE_CASE_TYPE), NON_DELETABLE_CASE_DATA_WITH_PAST_TTL, true),
+            Arguments.of(List.of(TestData.DELETABLE_CASE_TYPE), NON_DELETABLE_CASE_DATA_WITH_MISSING_TTL, true),
             Arguments.of(emptyList(), DELETABLE_CASE_DATA_WITH_TODAY_TTL, true)
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/ccd/policy/TtlRetentionPolicyImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/policy/TtlRetentionPolicyImplTest.java
@@ -28,12 +28,14 @@ class TtlRetentionPolicyImplTest {
     }
 
     @Test
-    void testShouldRaiseNullPointerExceptionWhenDateIsNull() {
+    void testShouldReturnTrueWhenDateIsNull() {
         // GIVEN
         final CaseData caseData = new CaseData(2L, 2L, DELETABLE_CASE_TYPE, null, 2L, null);
 
         // WHEN/THEN
-        assertThatNullPointerException().isThrownBy(() -> underTest.mustRetain(caseData));
+        assertThat(underTest.mustRetain(caseData))
+            .isNotNull()
+            .isTrue();
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/hmcts/reform/ccd/service/CaseFinderServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/service/CaseFinderServiceTest.java
@@ -39,6 +39,7 @@ import static uk.gov.hmcts.reform.ccd.fixture.TestData.DELETABLE_CASE_DATA4_WITH
 import static uk.gov.hmcts.reform.ccd.fixture.TestData.DELETABLE_CASE_DATA5_WITH_PAST_TTL;
 import static uk.gov.hmcts.reform.ccd.fixture.TestData.DELETABLE_CASE_DATA_WITH_PAST_TTL;
 import static uk.gov.hmcts.reform.ccd.fixture.TestData.DELETABLE_CASE_DATA_WITH_TODAY_TTL;
+import static uk.gov.hmcts.reform.ccd.fixture.TestData.LINKED_CASE_DATA_MISSING_TTL_R102;
 import static uk.gov.hmcts.reform.ccd.fixture.TestData.LINKED_CASE_DATA_R10;
 import static uk.gov.hmcts.reform.ccd.fixture.TestData.LINKED_CASE_DATA_R100;
 import static uk.gov.hmcts.reform.ccd.fixture.TestData.LINKED_CASE_DATA_R101;
@@ -191,7 +192,7 @@ class CaseFinderServiceTest {
         final List<CaseData> linkedCases2 = List.of(LINKED_CASE_DATA_R11);
         final List<CaseData> linkedCases3 = List.of(LINKED_CASE_DATA_R12);
         final List<CaseData> linkedCases4 = List.of(LINKED_CASE_DATA_R10, LINKED_CASE_DATA_R11);
-        final List<CaseData> linkedCases5 = List.of(LINKED_CASE_DATA_R101);
+        final List<CaseData> linkedCases5 = List.of(LINKED_CASE_DATA_R101, LINKED_CASE_DATA_MISSING_TTL_R102);
         final List<CaseData> linkedCases6 = List.of(LINKED_CASE_DATA_R10);
         final List<CaseData> linkedCases7 = List.of(LINKED_CASE_DATA_R12);
         final List<CaseData> linkedCases8 = List.of(LINKED_CASE_DATA_R11, LINKED_CASE_DATA_R12);
@@ -229,8 +230,9 @@ class CaseFinderServiceTest {
 
                     assertThat(actualCaseIds)
                             .isNotEmpty()
-                            .hasSize(13)
-                            .hasSameElementsAs(List.of(1L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 91L, 92L, 100L, 101L, 1000L));
+                            .hasSize(14)
+                            .hasSameElementsAs(
+                                List.of(1L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 91L, 92L, 100L, 101L, 102L, 1000L));
                 });
     }
 
@@ -267,7 +269,7 @@ class CaseFinderServiceTest {
 
     @Test
     void testFindCasesDueDeletionShouldReturnEmpty() {
-        final List<CaseData> linkedCases = List.of(LINKED_CASE_DATA_R101);
+        final List<CaseData> linkedCases = List.of(LINKED_CASE_DATA_R101, LINKED_CASE_DATA_MISSING_TTL_R102);
         final CaseFamily caseFamily = new CaseFamily(DELETABLE_CASE_DATA5_WITH_PAST_TTL, linkedCases);
 
         final List<CaseFamily> deletableCaseFamilies = List.of(caseFamily);

--- a/src/test/java/uk/gov/hmcts/reform/ccd/service/remote/RestClientBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/service/remote/RestClientBuilderTest.java
@@ -15,6 +15,8 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.glassfish.jersey.client.ClientProperties.CONNECT_TIMEOUT;
+import static org.glassfish.jersey.client.ClientProperties.READ_TIMEOUT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -22,6 +24,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
+import static uk.gov.hmcts.reform.ccd.util.RestConstants.AUTHORISATION_HEADER;
 import static uk.gov.hmcts.reform.ccd.util.RestConstants.SERVICE_AUTHORISATION_HEADER;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,9 +33,8 @@ class RestClientBuilderTest {
     @Mock
     private SecurityUtil securityUtil;
 
-
     @Test
-    void shouldReturnRestClient() {
+    void shouldReturnRestClientWithServiceUthHeader() {
         final Client client = mock(Client.class);
         final WebTarget webTarget = mock(WebTarget.class);
         final Invocation.Builder builder = mock(Invocation.Builder.class);
@@ -51,11 +53,50 @@ class RestClientBuilderTest {
         when(webTarget.request()).thenReturn(builder);
         when(builder.header(SERVICE_AUTHORISATION_HEADER, "Bearer 12345")).thenReturn(builder);
         when(builder.post(Entity.json(requestBody))).thenReturn(response);
-        when(response.readEntity(String.class)).thenReturn("Web client resposnse");
+        when(response.readEntity(String.class)).thenReturn("Web client response");
 
         final String postResponse = restClientBuilder.postRequestWithServiceAuthHeader("http://localhost:9090", "/delete", requestBody);
 
         verify(response, times(1)).readEntity(String.class);
-        assertThat(postResponse).isEqualTo("Web client resposnse");
+        assertThat(postResponse).isEqualTo("Web client response");
+    }
+
+    @Test
+    void shouldReturnRestClientWithAllHeaders() {
+        final Client client = mock(Client.class);
+        final WebTarget webTarget = mock(WebTarget.class);
+        final Invocation.Builder builder = mock(Invocation.Builder.class);
+        final Response response = mock(Response.class);
+
+        final RestClientBuilder restClientBuilder = new RestClientBuilder(securityUtil);
+        final DocumentsDeletePostRequest documentsDeleteRequest = new DocumentsDeletePostRequest("123");
+        final Gson gson = new Gson();
+        final String requestBody = gson.toJson(documentsDeleteRequest);
+
+        setField(restClientBuilder, "client", client);
+
+        doReturn("Bearer 12345").when(securityUtil).getServiceAuthorization();
+        doReturn("Bearer 5678").when(securityUtil).getIdamClientToken();
+        when(client.target(any(String.class))).thenReturn(webTarget);
+        when(webTarget.path(any(String.class))).thenReturn(webTarget);
+        when(webTarget.request()).thenReturn(builder);
+        when(builder.header(SERVICE_AUTHORISATION_HEADER, "Bearer 12345")).thenReturn(builder);
+        when(builder.header(AUTHORISATION_HEADER, "Bearer 5678")).thenReturn(builder);
+        when(builder.post(Entity.json(requestBody))).thenReturn(response);
+
+        final Response postResponse = restClientBuilder.postRequestWithAllHeaders("http://localhost:9090", "/delete",
+                requestBody);
+
+        assertThat(postResponse).isEqualTo(response);
+    }
+
+
+    @Test
+    void shouldGetClient() {
+        final RestClientBuilder restClientBuilder = new RestClientBuilder(securityUtil);
+        final Client client = restClientBuilder.getClient();
+
+        assertThat(client.getConfiguration().getProperty(READ_TIMEOUT)).isEqualTo(30000);
+        assertThat(client.getConfiguration().getProperty(CONNECT_TIMEOUT)).isEqualTo(50000);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/LAU-439


### Change description ###
Update to retain cases if TTL value is missing. Previously a NPE was thrown when a missing TTL was found in a linked case.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
