### PR TITLE
LAU-527 Update to fix helm uninstall not firing in build

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -96,7 +96,6 @@ withPipeline(type, product, component) {
   }
 
   enableAksStagingDeployment()
-  disableLegacyDeployment()
   nonServiceApp()
   syncBranchesWithMaster(branchesToSync)
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -97,7 +97,8 @@ withPipeline(type, product, component) {
 
   enableAksStagingDeployment()
   disableLegacyDeployment()
-  //nonServiceApp()
+  nonServiceApp()
+  enableCleanupOfHelmReleaseAlways()
   syncBranchesWithMaster(branchesToSync)
 
   onPR() {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -96,7 +96,8 @@ withPipeline(type, product, component) {
   }
 
   enableAksStagingDeployment()
-  nonServiceApp()
+  disableLegacyDeployment()
+  //nonServiceApp()
   syncBranchesWithMaster(branchesToSync)
 
   onPR() {

--- a/charts/ccd-case-disposer/Chart.yaml
+++ b/charts/ccd-case-disposer/Chart.yaml
@@ -19,6 +19,6 @@ dependencies:
     repository: 'https://helm.elastic.co'
     condition: elastic.enabled
   - name: ccd
-    version: 8.0.21
+    version: 8.0.23
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.enabled

--- a/charts/ccd-case-disposer/values.preview.template.yaml
+++ b/charts/ccd-case-disposer/values.preview.template.yaml
@@ -268,6 +268,7 @@ ccd:
         OIDC_ISSUER: https://forgerock-am.service.core-compute-idam-aat2.internal:8443/openam/oauth2/hmcts
       devmemoryRequests: "1024Mi"
       devmemoryLimits: "2048Mi"
+      disableKeyVaults: true
 
   ccd-user-profile-api:
     java:
@@ -276,6 +277,7 @@ ccd:
       imagePullPolicy: Always
       environment:
         USER_PROFILE_DB_HOST: "${SERVICE_NAME}-postgresql"
+      disableKeyVaults: true
 
   ccd-data-store-api:
     java:
@@ -309,6 +311,7 @@ ccd:
         IDAM_DATA_STORE_SYSTEM_USER_PASSWORD: ${IDAM_DATA_STORE_SYSTEM_USER_PASSWORD}
         IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET: ${IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET}
         ROLE_ASSIGNMENT_URL: http://am-role-assignment-service-aat.service.core-compute-aat.internal
+      disableKeyVaults: true
       autoscaling:
         enabled: false
 

--- a/charts/ccd-case-disposer/values.preview.template.yaml
+++ b/charts/ccd-case-disposer/values.preview.template.yaml
@@ -268,7 +268,6 @@ ccd:
         OIDC_ISSUER: https://forgerock-am.service.core-compute-idam-aat2.internal:8443/openam/oauth2/hmcts
       devmemoryRequests: "1024Mi"
       devmemoryLimits: "2048Mi"
-      keyVaults: [ ]
 
   ccd-user-profile-api:
     java:
@@ -277,7 +276,6 @@ ccd:
       imagePullPolicy: Always
       environment:
         USER_PROFILE_DB_HOST: "${SERVICE_NAME}-postgresql"
-      keyVaults: [ ]
 
   ccd-data-store-api:
     java:
@@ -311,7 +309,6 @@ ccd:
         IDAM_DATA_STORE_SYSTEM_USER_PASSWORD: ${IDAM_DATA_STORE_SYSTEM_USER_PASSWORD}
         IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET: ${IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET}
         ROLE_ASSIGNMENT_URL: http://am-role-assignment-service-aat.service.core-compute-aat.internal
-      keyVaults: [ ]
       autoscaling:
         enabled: false
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/LAU-527


### Change description ###
Remove redundant command disableLegacyDeployment() which is preventing helm release from uninstalling in pipeline.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
