### PR TITLE
Suppress CVE-2022-45688 as project does not contain json-java or hutool

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -21,6 +21,10 @@
     <packageUrl regex="true">^pkg:maven/org.yaml/snakeyaml@.*$</packageUrl>
     <cpe>cpe:/a:yaml_project:yaml</cpe>
   </suppress>
+  <suppress>
+    <notes>False positive as project does not contain json-java or hutool</notes>
+    <cve>CVE-2022-45688</cve>
+  </suppress>
   <!--End of false positives section -->
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/LAU-613


### Change description ###
Suppress CVE-2022-45688 as project does not contain json-java or hutool


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No