### PR TITLE
LAU-646 upgrade vulnerable to CVE-2023-20863 libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'pmd'
     id 'jacoco'
     id 'io.spring.dependency-management' version '1.1.0'
-    id 'org.springframework.boot' version '2.7.10'
+    id 'org.springframework.boot' version '2.7.11'
     id 'org.owasp.dependencycheck' version '8.2.1'
     id 'com.github.ben-manes.versions' version '0.46.0'
     id 'org.sonarqube' version '4.0.0.2929'
@@ -235,7 +235,7 @@ def versions = [
      gradlePitest        : '1.9.0',
      pitest              : '1.9.11',
      sonarPitest         : '0.5',
-     springFramework     : '5.3.26',
+     springFramework     : '5.3.27',
      apiGuardian         : '1.0.0',
      springBoot          : springBoot.class.package.implementationVersion,
 ]
@@ -250,7 +250,7 @@ ext.libraries = [
         ]
 ]
 
-ext['spring-framework.version'] = '5.3.26'
+ext['spring-framework.version'] = '5.3.27'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.14.1'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/LAU-646

### Change description ###

Minor versions bump to address CVE-2023-20863 vulnerability

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
