### PR TITLE
LAU-649 bump spring security version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -281,7 +281,7 @@ dependencies {
     configurations {
         compile.exclude module: 'spring-boot-starter-logging'
     }
-    implementation group: 'org.springframework.security', name: 'spring-security-crypto', version: '6.0.2'
+    implementation group: 'org.springframework.security', name: 'spring-security-crypto', version: '6.0.3'
 
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: versions.reformLogging
     implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: versions.reformLogging


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/projects/LAU/issues/LAU-649

### Change description ###

Bump spring security version which does not have CVE-2023-20862 vulnerability

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
