### PR TITLE
LAU-668 j-text-utils dependency suppression

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,7 +14,7 @@
   </suppress>
   <suppress>
     <packageUrl regex="true">^pkg:maven/com.massisframework/j-text-utils@.*$</packageUrl>
-    <cve>CVE-2021-4277</cve>
+    <cve>CVE-2023-2972</cve>
   </suppress>
   <suppress>
     <notes>False positive as project does not contain json-java or hutool</notes>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/LAU-668


### Change description ###
This change is to suppress dependency for j-tect-utils CVE-2023-2972


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
