### PR TITLE
LAU-1294 bump elasticsearch testcontainer image

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/ccd/config/es/TestContainers.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/ccd/config/es/TestContainers.java
@@ -20,7 +20,7 @@ public abstract class TestContainers {
 
     protected static final WireMockServer WIREMOCK_SERVER = new WireMockServer(4603);
     private static final Logger LOGGER = LoggerFactory.getLogger(TestContainers.class);
-    private static final String IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:7.17.1";
+    private static final String IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:7.17.29";
     private static final ElasticsearchContainer ELASTICSEARCH_CONTAINER = new ElasticsearchContainer(IMAGE)
             .withLogConsumer(new Slf4jLogConsumer(LOGGER))
             .waitingFor(Wait.forListeningPort());


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/LAU-1294

### Change description ###
Bump elasticsearch testcontainer image to 7.17.29

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
